### PR TITLE
Bug fix for Navigation Menu Item Hover State

### DIFF
--- a/src/components/Navbar.css
+++ b/src/components/Navbar.css
@@ -38,7 +38,6 @@
 .navigation-item::after {
     content: '';
     position: absolute;
-    display: block;
     width: 100%;
     transform: scaleX(0);
     height: 2px;

--- a/src/components/Navbar.css
+++ b/src/components/Navbar.css
@@ -26,15 +26,19 @@
     flex-direction: column;
 }
 
-.navigation-item:hover {
+.navigation-item {
     display: inline-block;
     position: relative;
+}
+
+.navigation-item:hover {
     color: #5f985f;
 }
 
 .navigation-item::after {
     content: '';
     position: absolute;
+    display: block;
     width: 100%;
     transform: scaleX(0);
     height: 2px;


### PR DESCRIPTION
- Move display and position to its own CSS block

The issue was that prior to this, `display: inline-block` and `position: relative` was only being applied to when `.navigation-item` was in a `:hover` state. Aside from that, `.navigation-item` had a property of `display: flex` that it was inheriting from `.navigation`.

Once you move those two properties to its own CSS block, the transition works as intended. (Btw, it's a nice little effect)